### PR TITLE
Updated codesniffer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val installAll =
       |&& curl -sS https://getcomposer.org/installer | php
       |&& mv composer.phar /usr/bin/composer
       |&& export COMPOSER_HOME=$$(pwd)/composer
-      |&& composer global require "squizlabs/php_codesniffer=2.6.2"
+      |&& composer global require "squizlabs/php_codesniffer=2.9.1"
       |&& ln -s $$COMPOSER_HOME/vendor/bin/phpcs /usr/bin/phpcs
       |&& git clone --branch 0.10.0 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wpcs
       |&& phpcs --config-set installed_paths $$(pwd)/wpcs


### PR DESCRIPTION
Version 2.9.1 is needed for many sniffs to work correctly with PHP 7.1 code, currently used version prints many false positives (over 1000 in one project). Version 3.0.0 should not be used for PHP 7.1, at least 1 important fix will be in next patch version but still no custom sniffs written for version 2.x will work.