### PR TITLE
Removes memory_limit when running

### DIFF
--- a/src/main/scala/codacy/codesniffer/CodeSniffer.scala
+++ b/src/main/scala/codacy/codesniffer/CodeSniffer.scala
@@ -68,7 +68,7 @@ object CodeSniffer extends Tool {
         "--standard=" + config.toString
     }
 
-    List("phpcs", "--report=xml", s"--report-file=$outputFile") ++ configurationFile ++ filesToLint
+    List("phpcs", "-d", "memory_limit=-1", "--report=xml", s"--report-file=$outputFile") ++ configurationFile ++ filesToLint
   }
 
   private def generateConfig(configurationOpt: Option[List[PatternDef]]): Option[Path] = {


### PR DESCRIPTION
Solves the "Allowed memory size of 134217728 bytes exhausted", and since the docker already limits memory, we can just remove it from the phpcs