### PR TITLE
Remove deprecated parameters on patterns

### DIFF
--- a/src/main/scala/codacy/codesniffer/docsgen/parsers/DocsParser.scala
+++ b/src/main/scala/codacy/codesniffer/docsgen/parsers/DocsParser.scala
@@ -71,7 +71,7 @@ trait DocsParser {
     val patternRegex = """.*?\spublic.*?\$(.*?)=(.*?);""".r
 
     Option(patternFile.lineIterator.toStream.collect {
-      case patternRegex(name, defaultValue) if !valueIsArray(defaultValue.trim)=>
+      case patternRegex(name, defaultValue) if !valueIsArray(defaultValue.trim) =>
         Parameter.Specification(Parameter.Name(name.trim), Parameter.Value(defaultValue.trim))
     }).filter(_.nonEmpty)
       .map(_.toSet)


### PR DESCRIPTION
Some deprecated parameters are being tracked which causes the tool to later report a deprecated error on Codacy. This PR removes parameters marked as @deprecated to avoid this issue.