### PR TITLE
Fix wordpress repository checkout commit

### DIFF
--- a/src/main/scala/codacy/codesniffer/docsgen/parsers/WordPressCSDocsParser.scala
+++ b/src/main/scala/codacy/codesniffer/docsgen/parsers/WordPressCSDocsParser.scala
@@ -10,7 +10,7 @@ class WordPressCSDocsParser extends DocsParser {
 
   override val repositoryURL = "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git"
 
-  override val checkoutCommit: String = VersionsHelper.phpCompatibility
+  override val checkoutCommit: String = VersionsHelper.wordpress
 
   override val sniffRegex: Regex = """.*WordPress\/Sniffs\/(.*?)\/(.*?)Sniff.php""".r
 


### PR DESCRIPTION
Due to the wordpress checkout commit not being correct, the tool was checking out to "master" thus causing some new incorrect patterns to appear.