### PR TITLE
updating composer for wpcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "wp-coding-standards/wpcs": "2.2.1",
         "phpcompatibility/php-compatibility": "9.3.5",
         "magento/marketplace-eqp": "4.0.0",
+        "wp-coding-standards/wpcs": "2.2.1",
         "drupal/coder": "8.3.8"
     },
     "repositories": [


### PR DESCRIPTION
Based on https://github.com/codacy/codacy-codesniffer/issues/60, the readme say that require to add the repo on composer (what that this pull requests does) and a Docs generator scala class that already exist in the repo right now https://github.com/codacy/codacy-codesniffer/blob/master/src/main/scala/codacy/codesniffer/docsgen/parsers/WordPressCSDocsParser.scala